### PR TITLE
Same room name add issue fixed

### DIFF
--- a/myClasses/ManageRoom.java
+++ b/myClasses/ManageRoom.java
@@ -174,9 +174,10 @@ public class ManageRoom extends JFrame implements ActionListener {
         } else if (e.getSource() == add_btn) {
             boolean flag = false;
             try (BufferedReader br = new BufferedReader(new FileReader("./files/rooms.txt"))) {
+                String line;
                 // Check if the room number already exists in the file
-                while ((br.readLine()) != null) {
-                    if (br.readLine().equals(roomNum_fld.getText())) {
+                while ((line = br.readLine()) != null) {
+                    if (line.equals(roomNum_fld.getText())) {
                         flag = true;
                         break;
                     }


### PR DESCRIPTION
In MangeRoom.java if someone want to add a room which room number is already exist than it should allow user to add new room. The issue in the code lies in the while loop condition and its execution. In each iteration of the loop, it is calling br.readLine() twice, which skips a line from the file.
In this updated code, I assign the line read from the file to the line variable within the loop condition. This way, the same line is used for the comparison within the loop's block, ensuring that it is not skipped.