### PR TITLE
fix: BkashPayment needs 5 digit to checkout and Nagad needs 4 digitNa…

### DIFF
--- a/myClasses/BkashPayment.java
+++ b/myClasses/BkashPayment.java
@@ -85,4 +85,24 @@ public class BkashPayment extends JFrame implements ActionListener, ConfirmPayme
         }
     }
 
+    @Override
+    public boolean inputLength(JTextField number, JPasswordField password) {
+        String numberText = number.getText();
+        String passText = String.valueOf(password.getPassword());
+
+        if (numberText.length() != 11 && passText.length() != 5) {
+            JOptionPane.showMessageDialog(null, "Phone number must contain exactly 11 digits and PIN number must contain exactly 5 digits", "Length error", JOptionPane.WARNING_MESSAGE);
+            return false;
+        } else if (numberText.length() != 11) {
+            JOptionPane.showMessageDialog(null, "Phone number must contain exactly 11 digits", "Length error", JOptionPane.WARNING_MESSAGE);
+            return false;
+        } else if (passText.length() != 5) {
+            JOptionPane.showMessageDialog(null, "PIN number must contain exactly 4 digits", "Length error", JOptionPane.WARNING_MESSAGE);
+            return false;
+        }
+
+        return true;
+    }
+
+
 }


### PR DESCRIPTION
NitPaul1304-10

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
BkashPayment now needs 5 digit to checkout and NagadPayment needs 4 digit.

Issue #10  this PR fixes BkashPayment inputLength funtion got overridden
## Related Tickets & Documents

Fixes #10  

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
